### PR TITLE
Fix case sensitive class name

### DIFF
--- a/components/Comments.php
+++ b/components/Comments.php
@@ -1,7 +1,7 @@
 <?php namespace Alxy\Facebook\Components;
 
 use Cms\Classes\ComponentBase;
-use HTML;
+use Html;
 use Alxy\Facebook\Models\Settings;
 
 class Comments extends ComponentBase
@@ -103,7 +103,7 @@ class Comments extends ComponentBase
                     "ch" => "Chamorro",
                     "co" => "Corsican",
                     "cr" => "Cree",
-                    "cs" => "Czech",
+                    "cs_CZ" => "Czech",
                     "cu" => "Church Slavic",
                     "cv" => "Chuvash",
                     "cy" => "Welsh",
@@ -282,7 +282,7 @@ class Comments extends ComponentBase
                     break;
             }
         });
-        $this->attributes = HTML::attributes($attributes);
+        $this->attributes = Html::attributes($attributes);
         $this->lang = $this->property('lang');
         $this->appId = Settings::get('app_id');
     }

--- a/components/Follow.php
+++ b/components/Follow.php
@@ -1,7 +1,7 @@
 <?php namespace Alxy\Facebook\Components;
 
 use Cms\Classes\ComponentBase;
-use HTML;
+use Html;
 use Alxy\Facebook\Models\Settings;
 
 class Follow extends ComponentBase
@@ -101,7 +101,7 @@ class Follow extends ComponentBase
                     "ch" => "Chamorro",
                     "co" => "Corsican",
                     "cr" => "Cree",
-                    "cs" => "Czech",
+                    "cs_CZ" => "Czech",
                     "cu" => "Church Slavic",
                     "cv" => "Chuvash",
                     "cy" => "Welsh",
@@ -280,7 +280,7 @@ class Follow extends ComponentBase
                     break;
             }
         });
-        $this->attributes = HTML::attributes($attributes);
+        $this->attributes = Html::attributes($attributes);
         $this->lang = $this->property('lang');
         $this->appId = Settings::get('app_id');
     }

--- a/components/Like.php
+++ b/components/Like.php
@@ -1,7 +1,7 @@
 <?php namespace Alxy\Facebook\Components;
 
 use Cms\Classes\ComponentBase;
-use HTML;
+use Html;
 use Alxy\Facebook\Models\Settings;
 
 class Like extends ComponentBase
@@ -117,7 +117,7 @@ class Like extends ComponentBase
                     "ch" => "Chamorro",
                     "co" => "Corsican",
                     "cr" => "Cree",
-                    "cs" => "Czech",
+                    "cs_CZ" => "Czech",
                     "cu" => "Church Slavic",
                     "cv" => "Chuvash",
                     "cy" => "Welsh",
@@ -296,7 +296,7 @@ class Like extends ComponentBase
                     break;
             }
         });
-        $this->attributes = HTML::attributes($attributes);
+        $this->attributes = Html::attributes($attributes);
         $this->lang = $this->property('lang');
         $this->appId = Settings::get('app_id');
     }

--- a/components/Send.php
+++ b/components/Send.php
@@ -1,7 +1,7 @@
 <?php namespace Alxy\Facebook\Components;
 
 use Cms\Classes\ComponentBase;
-use HTML;
+use Html;
 use Alxy\Facebook\Models\Settings;
 
 class Send extends ComponentBase
@@ -93,7 +93,7 @@ class Send extends ComponentBase
                     "ch" => "Chamorro",
                     "co" => "Corsican",
                     "cr" => "Cree",
-                    "cs" => "Czech",
+                    "cs_CZ" => "Czech",
                     "cu" => "Church Slavic",
                     "cv" => "Chuvash",
                     "cy" => "Welsh",
@@ -272,7 +272,7 @@ class Send extends ComponentBase
                     break;
             }
         });
-        $this->attributes = HTML::attributes($attributes);
+        $this->attributes = Html::attributes($attributes);
         $this->lang = $this->property('lang');
         $this->appId = Settings::get('app_id');
     }

--- a/components/Share.php
+++ b/components/Share.php
@@ -1,7 +1,7 @@
 <?php namespace Alxy\Facebook\Components;
 
 use Cms\Classes\ComponentBase;
-use HTML;
+use Html;
 use Alxy\Facebook\Models\Settings;
 
 class Share extends ComponentBase
@@ -80,7 +80,7 @@ class Share extends ComponentBase
                     "ch" => "Chamorro",
                     "co" => "Corsican",
                     "cr" => "Cree",
-                    "cs" => "Czech",
+                    "cs_CZ" => "Czech",
                     "cu" => "Church Slavic",
                     "cv" => "Chuvash",
                     "cy" => "Welsh",
@@ -259,7 +259,7 @@ class Share extends ComponentBase
                     break;
             }
         });
-        $this->attributes = HTML::attributes($attributes);
+        $this->attributes = Html::attributes($attributes);
         $this->lang = $this->property('lang');
         $this->appId = Settings::get('app_id');
     }


### PR DESCRIPTION
Fix case sensitive loading class Html. And fix Czech locale string - only with "cs" it doesn't works - tested now on last OctoberCMS build.

![snimek obrazovky 2016-04-27 v 0 00 52](https://cloud.githubusercontent.com/assets/374917/14836098/fa50f0a4-0c0d-11e6-826a-2c3ccb117672.png)

For loading Facebook SDK I think you have to use this special 4 char locale identifier:

![snimek obrazovky 2016-04-27 v 0 22 26](https://cloud.githubusercontent.com/assets/374917/14836149/4b7ecae6-0c0e-11e6-8191-ffcde869acec.png)
